### PR TITLE
fix: is_spam always returned None due to missing return statement

### DIFF
--- a/agent/engines/twitter/reply_manager.py
+++ b/agent/engines/twitter/reply_manager.py
@@ -3,6 +3,7 @@ import random
 import re
 import time
 from typing import List, Tuple
+from unicodedata import normalize
 
 from engines.memory.significance_scorer import SignificanceScorer
 from engines.twitter.post_maker import PostMaker
@@ -89,15 +90,12 @@ class ReplyManager:
 
     def is_spam(self, content: str) -> bool:
         """Check if content appears to be spam."""
-        import re
-        from unicodedata import normalize
-
         # Normalize more aggressively: remove all whitespace, symbols, zero-width chars
-        clean = re.sub(r'[\s\.\-_\|\\/\(\)\[\]\u200b-\u200f\u2060\ufeff]+', '', 
+        clean = re.sub(r'[\s\.\-_\|\\/\(\)\[\]\u200b-\u200f\u2060\ufeff]+', '',
                        normalize('NFKC', content.lower()))
 
         patterns = [
-            r'[\$\€\¢\£\¥]|(?:usd[t]?|usdc|busd)',  
+            r'[\$\€\¢\£\¥]|(?:usd[t]?|usdc|busd)',
             r'(?:ca|с[aа]|market.?cap)[:\|/]?(?:\d|soon)',
             r't[i1І]ck[e3Е]r|symb[o0]l|(?:trading|list).?pairs?',
             r'p[uüūи][mм]p|рuмр|ⓟⓤⓜⓟ|accumulate',
@@ -116,3 +114,4 @@ class ReplyManager:
             r'(?:early|earlybird|early.?access)',
             r'(?:t\.me|discord\.gg|dex\.tools)',
         ]
+        return any(re.search(pattern, clean) for pattern in patterns)


### PR DESCRIPTION
## Summary

Fixes #4.

`is_spam()` in `reply_manager.py` built an extensive list of regex patterns for detecting crypto spam but **never evaluated them** — the function fell off the end and implicitly returned `None`. As a result, `_should_reply()` never applied the `-3` spam penalty, and the agent replied to every piece of spam as if it were legitimate.

### Root cause

```python
# Before — no return statement; function silently returns None
def is_spam(self, content: str) -> bool:
    ...
    patterns = [ ... ]
    # <-- nothing here
```

### Fix

```python
# After
        return any(re.search(pattern, clean) for pattern in patterns)
```

Also removes two redundant per-call imports (`import re` and `from unicodedata import normalize`) that duplicated the module-level imports already present at the top of the file.

## Changes

- `agent/engines/twitter/reply_manager.py`
  - Add missing `return` to `is_spam()`
  - Move `from unicodedata import normalize` to module-level imports
  - Remove `import re` / `from unicodedata import normalize` from inside the function body

## Test plan

- [ ] `is_spam("🚀 100x moon soon buy now")` returns `True`
- [ ] `is_spam("interesting take on the consensus mechanism")` returns `False`
- [ ] `_should_reply()` correctly penalises spam content with a `-3` score adjustment