### PR TITLE
fix: resolve PostSender._post_content self.config AttributeError and wrong caller in pipeline

### DIFF
--- a/agent/engines/twitter/post_sender.py
+++ b/agent/engines/twitter/post_sender.py
@@ -81,17 +81,18 @@ class PostSender:
 
         except Exception as e:
             print(f"Error verifying tweet post: {str(e)}")
+            return False
 
 
 
-    def _post_content(self, content: str) -> Optional[str]:
+    def _post_content(self, auth, account: Account, content: str) -> Optional[str]:
         """Attempt to post content using available methods."""
         # Try API method first
-        tweet_id = self.send_post_API(self.config.auth, content)
+        tweet_id = self.send_post_API(auth, content)
         if tweet_id:
             return tweet_id
         # Fallback to account method
-        response = self.send_post(self.config.account, content)
+        response = self.send_post(account, content)
         return (response.get('data', {})
                 .get('create_tweet', {})
                 .get('tweet_results', {})

--- a/agent/pipeline.py
+++ b/agent/pipeline.py
@@ -122,7 +122,7 @@ class PostingPipeline:
 
         # Post if significant enough
         if significance_score >= self.config.min_posting_significance_score:
-            tweet_id = self.post_maker._post_content(new_post_content)
+            tweet_id = self.post_sender._post_content(self.config.auth, self.config.account, new_post_content)
             if tweet_id:
                 new_post = Post(
                     content=new_post_content,


### PR DESCRIPTION
## Summary

Fixes two related bugs that together prevent any tweet from ever being posted:

### Bug 1: `pipeline.py` calls `_post_content` on the wrong object

`PostingPipeline.run()` called `self.post_maker._post_content(new_post_content)`, but `_post_content` is defined on `PostSender`, not `PostMaker`. This raises `AttributeError: 'PostMaker' object has no attribute '_post_content'` every time the pipeline attempts to post.

### Bug 2: `PostSender._post_content` references undefined `self.config`

`PostSender.__init__` accepts no arguments and stores no state, yet `_post_content` used `self.config.auth` and `self.config.account`, causing an `AttributeError` whenever the method was reached. The fix makes `auth` and `account` explicit parameters, consistent with how the other `PostSender` methods already work (`send_post_API`, `send_post`).

### Bug 3 (opportunistic): `verify_post_success` silently returns `None` on exception

The `except` block in `verify_post_success` printed the error but fell off the end of the function, returning `None` instead of `False`. Callers check the boolean truthiness of the return value, so this made a failed verification look indeterminate.

## Changes

- `agent/engines/twitter/post_sender.py`
  - `_post_content`: replace `self.config.auth` / `self.config.account` with explicit `auth` and `account` parameters
  - `verify_post_success`: add `return False` in the `except` block

- `agent/pipeline.py`
  - Change `self.post_maker._post_content(new_post_content)` to `self.post_sender._post_content(self.config.auth, self.config.account, new_post_content)`

## Test plan

- [ ] Pipeline completes a full run without `AttributeError` on `_post_content`
- [ ] A generated post with a significance score above the threshold is successfully tweeted
- [ ] `verify_post_success` returns `False` (not `None`) when an exception occurs

https://claude.ai/code/session_01E3wXo2TKRt3wh3mt7cPWLg