### PR TITLE
Fix is_spam method: add missing return statement

### DIFF
--- a/agent/engines/twitter/reply_manager.py
+++ b/agent/engines/twitter/reply_manager.py
@@ -116,3 +116,5 @@ class ReplyManager:
             r'(?:early|earlybird|early.?access)',
             r'(?:t\.me|discord\.gg|dex\.tools)',
         ]
+
+        return any(re.search(pattern, clean) for pattern in patterns)


### PR DESCRIPTION
The `is_spam` method in `reply_manager.py` defined spam pattern regexes but never actually checked them against the content, always returning `None`.

**Changes:**
- Added `return any(re.search(pattern, clean) for pattern in patterns)` at the end of `is_spam` to properly check the cleaned content against all spam patterns and return `True`/`False`.

Fixes #4